### PR TITLE
Implement some fixes.

### DIFF
--- a/pawno/include/queue.inc
+++ b/pawno/include/queue.inc
@@ -10,6 +10,16 @@
 #define INVALID_QUEUE_VALUE -1  
 
 // ------------------------------------- //
+//             Macro guards              //
+// ------------------------------------- //
+
+#define Queue@%0\32; Queue@
+#define Queue@front_%0\32; Queue@front_
+#define Queue@back_%0\32; Queue@back_
+#define Queue@count_%0\32; Queue@count_
+#define Queue@size_%0\32; Queue@size_
+
+// ------------------------------------- //
 //              Definition               //
 // ------------------------------------- //
 


### PR DESCRIPTION
This implements a fix for an error when where you did this:

```c
new Queue: queue<SIZE>;
```

You would get an error as there is a space between a `Queue:` tag and a queue name.